### PR TITLE
Ensure that CI is triggered by pull requests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
With the current configuration, CI is only triggered by push,
so pull requests from forked repositories will not trigger CI.

Therefore, added pull_request to on so that it will be triggered by pull requests.